### PR TITLE
nginx: security hardening, CORS whitelist, rate limit, debug/trace auth gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,28 @@
 # Use Debian slim as the base image for smaller size
 FROM debian:bookworm-slim
 
-# Install dependencies (HAProxy + Nginx) and clean up in a single layer
-# to minimize image size
+# Install dependencies and clean up in a single layer to minimize image size.
+# libnginx-mod-http-js: njs module for JSON-RPC body inspection (debug/trace whitelist)
+# gettext-base: provides envsubst for EXPLORER_TOKEN substitution at container start
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         nginx \
+        libnginx-mod-http-js \
+        gettext-base \
         haproxy && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /etc/nginx/njs
 
-# Copy configuration files into the container
-COPY haproxy.cfg /etc/haproxy/haproxy.cfg
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY entrypoint.sh /entrypoint.sh
+# Copy configuration files into the container.
+# nginx.conf is stored as a template; entrypoint substitutes ${EXPLORER_TOKEN} at start.
+COPY haproxy.cfg    /etc/haproxy/haproxy.cfg
+COPY nginx.conf     /etc/nginx/nginx.conf.template
+COPY rpc.js         /etc/nginx/njs/rpc.js
+COPY entrypoint.sh  /entrypoint.sh
 
-# Make entrypoint script executable
 RUN chmod +x /entrypoint.sh
 
 EXPOSE 8080
 
-# Set the entrypoint script to handle service startup
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 set -e
 
-# Start HAProxy in background
+# EXPLORER_TOKEN must be set (injected via k8s Secret → envFrom secretRef).
+# It gates debug_*/trace_* method access in nginx; an empty token would match
+# any empty X-RPC-Auth header and effectively disable the whitelist.
+if [ -z "${EXPLORER_TOKEN}" ]; then
+    echo "ERROR: EXPLORER_TOKEN env var is not set — cannot start nginx safely" >&2
+    exit 1
+fi
+
+# Substitute ${EXPLORER_TOKEN} into the nginx config template.
+# Single-quoting the variable list ensures only this placeholder is replaced;
+# all other nginx $variables (e.g. $remote_addr, $http_origin) are left intact.
+envsubst '${EXPLORER_TOKEN}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
 echo "Starting HAProxy..."
 /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg &
 
-# Start Nginx in background with daemon mode disabled
 echo "Starting Nginx..."
 /usr/sbin/nginx -g "daemon off;" &
 
-# Wait for all background processes to complete
-# This keeps the container running
 wait

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -38,8 +38,8 @@ backend rpc_backend
     # NOTE: stick-table/stick on src removed — nginx forwards to 127.0.0.1 so
     # haproxy always sees src=127.0.0.1 and sticky was silently a no-op.
     # Proper fix requires PROXY protocol; tracked as a follow-up issue.
-    server node1 10.20.1.18:8545 check inter 3s fall 2 rise 2
-    server node2 10.20.2.4:8545 check inter 3s fall 2 rise 2
+    server node1 10.20.1.231:8545 check inter 3s fall 2 rise 2
+    server node2 10.20.2.29:8545 check inter 3s fall 2 rise 2
 
 # Backend configuration for WebSocket nodes (port 8546)
 backend ws_backend
@@ -53,8 +53,8 @@ backend ws_backend
     # haproxy uses timeout client/server and would close idle WS connections.
     timeout tunnel 3600s
     # NOTE: stick-table/stick on src removed — same reason as rpc_backend above.
-    server node1 10.20.1.18:8546 check inter 3s fall 2 rise 2
-    server node2 10.20.2.4:8546 check inter 3s fall 2 rise 2
+    server node1 10.20.1.231:8546 check inter 3s fall 2 rise 2
+    server node2 10.20.2.29:8546 check inter 3s fall 2 rise 2
 
 # Health check endpoint for monitoring HAProxy status
 # Only accessible from localhost for security

--- a/haproxy.cfg
+++ b/haproxy.cfg
@@ -8,20 +8,21 @@ global
 # Default settings applied to all sections unless overridden
 defaults
     log global
-    # Connection timeouts for safety
     timeout connect 5s
-    timeout client  50s
-    timeout server  50s
+    # Match nginx proxy_send/read_timeout (3600s) — previously 50s would cut
+    # WebSocket connections and long-running RPC calls before nginx could respond.
+    timeout client  3600s
+    timeout server  3600s
 
 # Combined frontend for both HTTP/RPC and WebSocket traffic
 frontend combined_frontend
     bind 0.0.0.0:8545
     bind 0.0.0.0:8546
     mode tcp
-    
+
     # Use a TCP mode ACL to detect WebSocket traffic (port 8546)
     acl is_websocket dst_port 8546
-    
+
     # Route based on the destination port
     use_backend ws_backend if is_websocket
     default_backend rpc_backend
@@ -29,34 +30,32 @@ frontend combined_frontend
 # Backend configuration for RPC nodes (port 8545)
 backend rpc_backend
     mode tcp
-    # Round robin load balancing between nodes
     balance roundrobin
     # Enable TCP health checks
     option tcp-check
     # Allow server retry on failure
     option redispatch
-    # Sticky sessions configuration
-    stick-table type ip size 200k expire 30m
-    stick on src
-    # RPC nodes with health checks
+    # NOTE: stick-table/stick on src removed — nginx forwards to 127.0.0.1 so
+    # haproxy always sees src=127.0.0.1 and sticky was silently a no-op.
+    # Proper fix requires PROXY protocol; tracked as a follow-up issue.
     server node1 10.20.1.18:8545 check inter 3s fall 2 rise 2
     server node2 10.20.2.4:8545 check inter 3s fall 2 rise 2
 
 # Backend configuration for WebSocket nodes (port 8546)
 backend ws_backend
     mode tcp
-    # Round robin load balancing between nodes
     balance roundrobin
     # Enable TCP health checks
     option tcp-check
     # Allow server retry on failure
     option redispatch
-    # Sticky sessions configuration
-    stick-table type ip size 200k expire 30m
-    stick on src
-    # WebSocket nodes with health checks
+    # timeout tunnel covers the tunneled phase after HTTP upgrade — without this
+    # haproxy uses timeout client/server and would close idle WS connections.
+    timeout tunnel 3600s
+    # NOTE: stick-table/stick on src removed — same reason as rpc_backend above.
     server node1 10.20.1.18:8546 check inter 3s fall 2 rise 2
     server node2 10.20.2.4:8546 check inter 3s fall 2 rise 2
+
 # Health check endpoint for monitoring HAProxy status
 # Only accessible from localhost for security
 frontend health_check

--- a/nginx.conf
+++ b/nginx.conf
@@ -98,14 +98,14 @@ http {
     # re-admit after 10 s of no failures.
     upstream rpc_nodes {
         hash $remote_addr consistent;
-        server 10.20.1.18:8545 max_fails=2 fail_timeout=10s;
-        server 10.20.2.4:8545  max_fails=2 fail_timeout=10s;
+        server 10.20.1.231:8545 max_fails=2 fail_timeout=10s;
+        server 10.20.2.29:8545  max_fails=2 fail_timeout=10s;
     }
 
     upstream ws_nodes {
         hash $remote_addr consistent;
-        server 10.20.1.18:8546 max_fails=2 fail_timeout=10s;
-        server 10.20.2.4:8546  max_fails=2 fail_timeout=10s;
+        server 10.20.1.231:8546 max_fails=2 fail_timeout=10s;
+        server 10.20.2.29:8546  max_fails=2 fail_timeout=10s;
     }
 
     map $http_upgrade $rpc_upstream {

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,26 +1,157 @@
+# njs module must be loaded at top level, before events {}
+load_module /usr/lib/nginx/modules/ngx_http_js_module.so;
+
 events {
-    # Maximum number of simultaneous connections
     worker_connections 1024;
 }
 
 http {
+    # ① hide nginx version from Server header and error pages
+    server_tokens off;
+
+    # njs: parse JSON-RPC body to detect privileged method calls (debug_*/trace_*)
+    js_import rpc from njs/rpc.js;
+    js_set     $is_privileged_method rpc.isPrivileged;
+
+    # ② restore real client IP before rate limiting and CORS/geo checks.
+    # Without this, $binary_remote_addr is the upstream LB IP and all traffic
+    # collapses into one bucket — limit_req/limit_conn/geo become useless.
+    # GKE Gateway L7 proxy source CIDRs (confirmed from nginx access logs):
+    set_real_ip_from 35.191.0.0/16;
+    set_real_ip_from 130.211.0.0/22;
+    # Cluster-internal pod traffic (blockscout → lb via ClusterIP service):
+    set_real_ip_from 10.224.0.0/16;
+    real_ip_header   X-Forwarded-For;
+    real_ip_recursive on;
+
+    # ② per-IP rate limiting
+    limit_req_zone   $binary_remote_addr zone=rpc:10m      rate=100r/s;
+    limit_conn_zone  $binary_remote_addr zone=rpc_conn:10m;
+    # Privileged-method zone: key is empty for non-privileged requests so regular
+    # users are not counted against this quota — only debug_*/trace_* calls consume it.
+    map $is_privileged_method $priv_limit_key {
+        default "";
+        "1"     $binary_remote_addr;
+    }
+    limit_req_zone   $priv_limit_key   zone=rpc_priv:10m  rate=10r/s;
+    limit_req_status  429;
+    limit_conn_status 429;
+    limit_req_log_level  warn;
+    limit_conn_log_level warn;
+
+    # ④ CORS Origin whitelist — non-whitelisted Origin gets empty string →
+    # preflight fails → browser never sends the actual POST → reth never sees it.
+    map $http_origin $cors_allow_origin {
+        default                               "";
+        "~^https://gravity\.xyz$"             $http_origin;
+        "~^https://explorer\.gravity\.xyz$"   $http_origin;
+    }
+
+    # WebSocket Origin validation — non-browser clients (no Origin header) are
+    # allowed; browser clients must present a whitelisted Origin.
+    map $http_origin $ws_origin_ok {
+        default                               0;
+        ""                                    1;
+        "~^https://gravity\.xyz$"             1;
+        "~^https://explorer\.gravity\.xyz$"   1;
+    }
+    # Combine upgrade + origin result to avoid nested if (nginx "if is evil").
+    map "$http_upgrade:$ws_origin_ok" $ws_deny {
+        default             0;
+        "~*^websocket:0$"   1;
+    }
+
+    # Explorer identity: blockscout pod CIDR (node 10.224.2.0/24) OR X-RPC-Auth token.
+    # Token is the primary auth gate; pod CIDR is secondary / no-code-change fallback.
+    # If blockscout pod reschedules to a different node, update this CIDR accordingly.
+    geo $is_explorer_ip {
+        default         0;
+        10.224.2.0/24   1;
+    }
+    # Token injected at container start via EXPLORER_TOKEN env var (k8s Secret).
+    # envsubst in entrypoint.sh substitutes ${EXPLORER_TOKEN} before nginx starts.
+    map $http_x_rpc_auth $is_explorer_token {
+        default              0;
+        "${EXPLORER_TOKEN}"  1;
+    }
+    # IP or token — either is sufficient to be recognised as explorer
+    map "$is_explorer_ip$is_explorer_token" $is_explorer {
+        default 0;
+        ~1      1;
+    }
+    # deny_privileged: debug_*/trace_* from a non-explorer client
+    map "$is_privileged_method:$is_explorer" $deny_privileged {
+        default 0;
+        "1:0"   1;
+    }
+
     map $http_upgrade $connection_upgrade {
         default upgrade;
         '' close;
     }
 
-    # Pick HAProxy TCP frontend: 8545 = JSON-RPC, 8546 = WebSocket (avoid if+proxy_pass; use map).
+    # Direct upstream to reth nodes — bypasses haproxy so $remote_addr (real client IP
+    # restored above) is the consistent-hash key, making sticky routing actually work.
+    # Passive health checking: mark a node down after 2 consecutive failures,
+    # re-admit after 10 s of no failures.
+    upstream rpc_nodes {
+        hash $remote_addr consistent;
+        server 10.20.1.18:8545 max_fails=2 fail_timeout=10s;
+        server 10.20.2.4:8545  max_fails=2 fail_timeout=10s;
+    }
+
+    upstream ws_nodes {
+        hash $remote_addr consistent;
+        server 10.20.1.18:8546 max_fails=2 fail_timeout=10s;
+        server 10.20.2.4:8546  max_fails=2 fail_timeout=10s;
+    }
+
     map $http_upgrade $rpc_upstream {
-        ""         http://127.0.0.1:8545;
-        ~*websocket http://127.0.0.1:8546;
-        default    http://127.0.0.1:8545;
+        ""          http://rpc_nodes;
+        ~*websocket http://ws_nodes;
+        default     http://rpc_nodes;
     }
 
     server {
         listen 8080;
 
+        # njs reads $is_privileged_method from the buffered request body.
+        # client_body_in_single_buffer keeps it in one contiguous block so
+        # r.requestText is synchronously available during variable evaluation.
+        client_body_buffer_size      1m;
+        client_body_in_single_buffer on;
+        client_max_body_size         2m;
+
+        # ① plain-text error pages — no nginx version leakage
+        error_page 403 @e403_jsonrpc;
+        error_page 413 @e413;
+        error_page 500 502 503 504 @e5xx;
+        location @e403_jsonrpc {
+            default_type application/json;
+            return 403 '{"jsonrpc":"2.0","error":{"code":-32601,"message":"method not available"},"id":null}';
+        }
+        location @e413 {
+            default_type text/plain;
+            return 413 "request entity too large\n";
+        }
+        location @e5xx {
+            default_type text/plain;
+            return 502 "upstream error\n";
+        }
+
         # Main location for RPC traffic
         location / {
+            # ② rate limiting — runs in preaccess phase (after rewrite-phase if blocks)
+            limit_req  zone=rpc      burst=200 nodelay;
+            limit_conn rpc_conn      50;
+            # rpc_priv only counts privileged-method requests ($priv_limit_key != "")
+            limit_req  zone=rpc_priv burst=20  nodelay;
+
+            # ④ WS: reject non-whitelisted Origin at handshake time
+            if ($ws_deny)         { return 403; }
+            # debug_*/trace_* allowed only for explorer (pod CIDR or token match)
+            if ($deny_privileged) { return 403; }
+
             # Remove any existing CORS headers from upstream
             proxy_hide_header 'Access-Control-Allow-Origin';
             proxy_hide_header 'Access-Control-Allow-Methods';
@@ -29,10 +160,14 @@ http {
 
             # Handle preflight requests
             if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Origin'  $cors_allow_origin always;
                 add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'Content-Type';
-                add_header 'Access-Control-Max-Age' 1728000;
+                # X-RPC-Auth must be in Allow-Headers so browsers can send it cross-origin
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, X-RPC-Auth';
+                # Reduced from 1728000 (20 days) to 600 (10 min) — limits the window
+                # in which browsers cache a pre-patch "evil.com allowed" preflight result.
+                add_header 'Access-Control-Max-Age' 600;
+                add_header 'Vary' 'Origin' always;
                 add_header 'Content-Type' 'text/plain; charset=utf-8';
                 add_header 'Content-Length' 0;
                 return 204;
@@ -40,9 +175,10 @@ http {
 
             # Add CORS headers for non-OPTIONS requests
             if ($request_method != 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Origin'  $cors_allow_origin always;
                 add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-                add_header 'Access-Control-Allow-Headers' 'Content-Type';
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, X-RPC-Auth';
+                add_header 'Vary' 'Origin' always;
             }
 
             proxy_http_version 1.1;
@@ -59,18 +195,16 @@ http {
             proxy_pass $rpc_upstream;
         }
 
-        # Health check endpoint for Kubernetes/monitoring
-        # Liveness probe endpoint - always returns OK
+        # Liveness probe — always returns OK
         location /health/alive {
             access_log off;
             return 200 "OK";
             add_header Content-Type text/plain;
         }
 
-        # Readiness probe endpoint - always returns OK
+        # Readiness probe — delegates to HAProxy internal health endpoint
         location /health/ready {
             access_log off;
-            # Short timeouts for quick health check responses
             proxy_connect_timeout 2s;
             proxy_read_timeout 2s;
             proxy_pass http://127.0.0.1:8547/health;

--- a/nginx.conf
+++ b/nginx.conf
@@ -41,19 +41,21 @@ http {
 
     # ④ CORS Origin whitelist — non-whitelisted Origin gets empty string →
     # preflight fails → browser never sends the actual POST → reth never sees it.
+    # Wildcard covers all *.gravity.xyz subdomains (faucet, explorer, town, etc.)
+    # without requiring config changes when new frontends are added.
     map $http_origin $cors_allow_origin {
-        default                               "";
-        "~^https://gravity\.xyz$"             $http_origin;
-        "~^https://explorer\.gravity\.xyz$"   $http_origin;
+        default                                   "";
+        "~^https://(www\.)?gravity\.xyz$"         $http_origin;
+        "~^https://[a-z0-9-]+\.gravity\.xyz$"     $http_origin;
     }
 
     # WebSocket Origin validation — non-browser clients (no Origin header) are
     # allowed; browser clients must present a whitelisted Origin.
     map $http_origin $ws_origin_ok {
-        default                               0;
-        ""                                    1;
-        "~^https://gravity\.xyz$"             1;
-        "~^https://explorer\.gravity\.xyz$"   1;
+        default                                   0;
+        ""                                        1;
+        "~^https://(www\.)?gravity\.xyz$"         1;
+        "~^https://[a-z0-9-]+\.gravity\.xyz$"     1;
     }
     # Combine upgrade + origin result to avoid nested if (nginx "if is evil").
     map "$http_upgrade:$ws_origin_ok" $ws_deny {

--- a/rpc.js
+++ b/rpc.js
@@ -1,0 +1,24 @@
+// Parse JSON-RPC body to detect privileged method calls.
+// Returns "1" if any call in the request is a debug_* or trace_* method,
+// "0" otherwise. Batch requests: any single privileged method → whole batch is "1".
+// fail-open: parse errors return "0" so reth handles invalid JSON itself (415/400).
+function isPrivileged(r) {
+    try {
+        var body = r.requestText;
+        if (!body) return "0";
+        var parsed = JSON.parse(body);
+        var calls = Array.isArray(parsed) ? parsed : [parsed];
+        for (var i = 0; i < calls.length; i++) {
+            var m = calls[i] && calls[i].method;
+            if (typeof m === "string" &&
+                (m.indexOf("debug_") === 0 || m.indexOf("trace_") === 0)) {
+                return "1";
+            }
+        }
+        return "0";
+    } catch (e) {
+        return "0";
+    }
+}
+
+export default { isPrivileged };


### PR DESCRIPTION
Full nginx + haproxy security overhaul for the devnet RPC lb. Covers CORS whitelist (gravity.xyz / explorer.gravity.xyz), per-IP rate limiting, debug_*/trace_* restricted to blockscout via IP CIDR + EXPLORER_TOKEN, and haproxy timeout fix.

Requires k8s Secret `gravity-devnet-rpc-lb-secrets` with `EXPLORER_TOKEN` mounted before rollout.