### PR TITLE
fix: add map_hash_bucket_size 128 for wildcard CORS regex

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,6 +9,9 @@ http {
     # ① hide nginx version from Server header and error pages
     server_tokens off;
 
+    # Wildcard regex patterns in map directives need a larger hash bucket.
+    map_hash_bucket_size 128;
+
     # njs: parse JSON-RPC body to detect privileged method calls (debug_*/trace_*)
     js_import rpc from njs/rpc.js;
     js_set     $is_privileged_method rpc.isPrivileged;


### PR DESCRIPTION
nginx fails to start with 'could not build map_hash, you should increase map_hash_bucket_size: 64' — caused by the *.gravity.xyz wildcard regex in map directives.